### PR TITLE
Use curl on macOS

### DIFF
--- a/fonts/install.sh
+++ b/fonts/install.sh
@@ -1,2 +1,11 @@
-wget https://github.com/adobe-fonts/source-han-code-jp/archive/2.000R.tar.gz
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+CMD=wget
+# On macOS, wget is not available by default.
+if [[ `uname -s` = "Darwin" ]]; then
+  CMD="curl -L -O"
+fi
+$CMD https://github.com/adobe-fonts/source-han-code-jp/archive/2.000R.tar.gz
 tar zxvf 2.000R.tar.gz


### PR DESCRIPTION
On macOS, `wget` is not available by default. `curl` is installed
instead.

Also, enable the `strict mode`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kiyukuta/string_recorder/2)
<!-- Reviewable:end -->
